### PR TITLE
Remove eLabel from MovieBrowserConfiguration screen

### DIFF
--- a/usr/share/enigma2/PLi-FullHD/skin.xml
+++ b/usr/share/enigma2/PLi-FullHD/skin.xml
@@ -1075,7 +1075,6 @@
 
 	<screen name="MovieBrowserConfiguration" position="fill" flags="wfNoBorder">
 		<panel name="PigTemplate"/>
-		<eLabel text="Movie list configuration" position="30,7" size="1830,75" backgroundColor="secondBG" transparent="1" zPosition="1" font="Regular;36" valign="center" halign="left"/>
 		<widget name="config" position="780,100" size="1110,912" itemHeight="38" font="Regular;28" transparent="1" scrollbarMode="showOnDemand"/>
 		<widget name="description" position="30,550" size="720,105" font="Regular;30" halign="left"/>
 	</screen>

--- a/usr/share/enigma2/PLi-FullNightHD/skin.xml
+++ b/usr/share/enigma2/PLi-FullNightHD/skin.xml
@@ -1056,7 +1056,6 @@
 
 	<screen name="MovieBrowserConfiguration" position="fill" flags="wfNoBorder">
 		<panel name="PigTemplate"/>
-		<eLabel text="Movie list configuration" position="30,7" size="1830,75" backgroundColor="secondBG" transparent="1" zPosition="1" font="Regular;36" valign="center" halign="left"/>
 		<widget name="config" position="780,100" size="1110,912" itemHeight="38" font="Regular;28" transparent="1" scrollbarMode="showOnDemand"/>
 		<widget name="description" position="30,550" size="720,105" font="Regular;30" halign="left"/>
 	</screen>

--- a/usr/share/enigma2/PLi-HD/skin.xml
+++ b/usr/share/enigma2/PLi-HD/skin.xml
@@ -926,7 +926,6 @@
 
   <screen name="MovieBrowserConfiguration" position="fill" flags="wfNoBorder">
     <panel name="PigTemplate"/>
-    <eLabel text="Movie list configuration" position="85,30" size="1085,55" backgroundColor="secondBG" transparent="1" zPosition="1" font="Regular;24" valign="center" halign="left" />
     <widget name="config" position="575,110" size="600,480" itemHeight="24" font="Regular;20" transparent="1" scrollbarMode="showOnDemand" selectionPixmap="PLi-HD/buttons/sel.png" />
     <widget name="description" position="85,370" size="417,92" transparent="1" font="Regular;20" halign="left"/>
   </screen>

--- a/usr/share/enigma2/PLi-HD1/skin.xml
+++ b/usr/share/enigma2/PLi-HD1/skin.xml
@@ -998,7 +998,6 @@
 
   <screen name="MovieBrowserConfiguration" position="fill" flags="wfNoBorder">
     <panel name="PigTemplate"/>
-    <eLabel text="Movie list configuration" position="20,5" size="1220,50" backgroundColor="secondBG" transparent="1" zPosition="1" font="Regular;24" valign="center" halign="left"/>
     <widget name="config" position="520,70" size="740,600" itemHeight="25" font="Regular;20" transparent="1" scrollbarMode="showOnDemand"/>
     <widget name="description" position="20,378" size="480,92" transparent="1" font="Regular;20" halign="left"/>
   </screen>

--- a/usr/share/enigma2/PLi-HD2/skin.xml
+++ b/usr/share/enigma2/PLi-HD2/skin.xml
@@ -937,7 +937,6 @@
 
   <screen name="MovieBrowserConfiguration" position="fill" flags="wfNoBorder">
     <panel name="PigTemplate"/>
-    <eLabel text="Movie list configuration" position="40,5" size="1200,50" backgroundColor="secondBG" transparent="1" zPosition="1" font="Regular;24" valign="center" halign="left" />
     <widget name="config" position="530,80" size="710,576" itemHeight="24" font="Regular;20" transparent="1" scrollbarMode="showOnDemand" selectionPixmap="PLi-HD/buttons/sel.png" />
     <widget name="description" position="40,370" size="462,92" transparent="1" font="Regular;20" halign="left"/>
   </screen>


### PR DESCRIPTION
As it is not required as title does set it. This solves double overlay
when screenPath mode is set to big